### PR TITLE
RenderXtdCommentTree - comments from context_dict

### DIFF
--- a/django_comments_xtd/templatetags/comments_xtd.py
+++ b/django_comments_xtd/templatetags/comments_xtd.py
@@ -328,14 +328,22 @@ class RenderXtdCommentTreeNode(Node):
             for vname, vobj in self.cvars:
                 context_dict[vname] = vobj.resolve(context)
         if not self.obj:
-            # Then presume 'comments' exists in the context.
-            try:
-                ctype = context['comments'][0]['comment'].content_type
-            except Exception:
+            # Then presume 'comments' exists in the context_dict or in context
+            if "comments" in context_dict:
+                comments = context_dict["comments"]
+            elif "comments" in context:
+                comments = context["comments"]
+            else:
                 raise TemplateSyntaxError("'render_xtdcomment_tree' doesn't "
                                           "have 'comments' in the context and "
                                           "neither have been provided with the "
                                           "clause 'with'.")
+            # empty list of comments
+            if not comments:
+                return ""
+
+            ctype = comments[0]['comment'].content_type
+
         if self.template_path:
             template_arg = self.template_path
         else:


### PR DESCRIPTION
Render comments from context_dict first if 'comments' were passed in cvars.

Let's say I don't have name 'comments' in context but I use 'top_comments'. Then I render comments with tag in the template:
`{% render_xtdcomment_tree with comments=top_commets %}`
This throws error because check is happening only in context but 'top_comments' are in context_dict